### PR TITLE
Fixed google spec test for handling "K" amount of shares

### DIFF
--- a/src/SocialShare/Provider/Google.php
+++ b/src/SocialShare/Provider/Google.php
@@ -55,7 +55,7 @@ class Google implements ProviderInterface
         libxml_use_internal_errors();
 
         // Instead of big numbers, Google returns strings like >10K
-        if (preg_match('/>([0-9]+)K/', $aggregateCount->nodeValue, $matches)) {
+        if (preg_match('/([0-9]+)K/', $aggregateCount->nodeValue, $matches)) {
            return $matches[1] * 1000;
         }
 


### PR DESCRIPTION
Issue was the regular expression was looking at a node element closure ('>') while in the DOMDocument you only get clean values

`public $nodeValue =>string(4) "10K+"`

Fixed the issue and ran phpspec with 100% locally