### PR TITLE
Fix the usage of http_build_query to avoid relying on ini settings

### DIFF
--- a/src/SocialShare/Provider/LinkedIn.php
+++ b/src/SocialShare/Provider/LinkedIn.php
@@ -48,7 +48,7 @@ class LinkedIn implements ProviderInterface
         $options['mini'] = 'true';
         $options['url'] = $url;
 
-        return sprintf(self::SHARE_URL, http_build_query($options));
+        return sprintf(self::SHARE_URL, http_build_query($options, null, '&'));
     }
 
     /**

--- a/src/SocialShare/Provider/Pinterest.php
+++ b/src/SocialShare/Provider/Pinterest.php
@@ -37,7 +37,7 @@ class Pinterest implements ProviderInterface
     {
         $options['url'] = $url;
 
-        return sprintf(self::SHARE_URL, http_build_query($options));
+        return sprintf(self::SHARE_URL, http_build_query($options, null, '&'));
     }
 
     /**

--- a/src/SocialShare/Provider/StumbleUpon.php
+++ b/src/SocialShare/Provider/StumbleUpon.php
@@ -37,7 +37,7 @@ class StumbleUpon implements ProviderInterface
     {
         $options['url'] = $url;
 
-        return sprintf(self::SHARE_URL, http_build_query($options));
+        return sprintf(self::SHARE_URL, http_build_query($options, null, '&'));
     }
 
     /**

--- a/src/SocialShare/Provider/Twitter.php
+++ b/src/SocialShare/Provider/Twitter.php
@@ -37,7 +37,7 @@ class Twitter implements ProviderInterface
     {
         $options['url'] = $url;
 
-        return sprintf(self::SHARE_URL, http_build_query($options));
+        return sprintf(self::SHARE_URL, http_build_query($options, null, '&'));
     }
 
     /**


### PR DESCRIPTION
When using the default arguments, the method is impacted by an ini setting.
Changing it to escape the separator early in http_build_query would lead to double escaping later as the contract of this library is that it returns an URL, not an URL already escaped for HTML context.