### PR TITLE
Fix restoring the libxml error handling

### DIFF
--- a/src/SocialShare/Provider/Google.php
+++ b/src/SocialShare/Provider/Google.php
@@ -46,13 +46,13 @@ class Google implements ProviderInterface
         $html = file_get_contents(sprintf(self::IFRAME_URL, urlencode($url)));
 
         // Disable libxml errors
-        libxml_use_internal_errors(true);
+        $internalErrors = libxml_use_internal_errors(true);
         $document = new \DOMDocument();
         $document->loadHTML($html);
         $aggregateCount = $document->getElementById('aggregateCount');
 
         // Restore libxml errors
-        libxml_use_internal_errors();
+        libxml_use_internal_errors($internalErrors);
 
         // Instead of big numbers, Google returns strings like >10K
         if (preg_match('/([0-9]+)K/', $aggregateCount->nodeValue, $matches)) {

--- a/src/SocialShare/Provider/ScoopIt.php
+++ b/src/SocialShare/Provider/ScoopIt.php
@@ -48,13 +48,13 @@ class ScoopIt implements ProviderInterface
         $html = file_get_contents(sprintf(self::BUTTON_URL, urlencode($url)));
 
         // Disable libxml errors
-        libxml_use_internal_errors(true);
+        $internalErrors = libxml_use_internal_errors(true);
         $document = new \DOMDocument();
         $document->loadHTML(self::DTD.$html);
         $aggregateCount = $document->getElementById('scoopit_count');
 
         // Restore libxml errors
-        libxml_use_internal_errors();
+        libxml_use_internal_errors($internalErrors);
 
         return intval($aggregateCount->nodeValue);
     }


### PR DESCRIPTION
The setting should be restored to its previous value, not be set to false.