### PR TITLE
[WIP] Use twitter REST api (search api) for counts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require": {
         "php": ">=5.3",
         "ext-json": "*",
-        "doctrine/cache": "~1.3.0"
+        "doctrine/cache": "~1.3.0",
+        "abraham/twitteroauth": "^0.6.2"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.0"

--- a/examples/buttons.php
+++ b/examples/buttons.php
@@ -17,13 +17,20 @@ $cache = new PhpFileCache(sys_get_temp_dir());
 $socialShare = new SocialShare($cache);
 
 $socialShare->registerProvider(new Facebook());
-$socialShare->registerProvider(new Twitter());
 $socialShare->registerProvider(new Google());
 $socialShare->registerProvider(new Pinterest());
 $socialShare->registerProvider(new LinkedIn());
 $socialShare->registerProvider(new ScoopIt());
 $socialShare->registerProvider(new StumbleUpon());
 $socialShare->registerProvider(new Tumblr());
+
+// Create an app here: https://apps.twitter.com/
+$twitterConsumerKey    = '__set_to_your_app_key__';             // app / Keys and Access Tokens, use "Consumer Key"
+$twitterConsumerSecret = '__set_to_your_app_secret__';          // app / Keys and Access Tokens, use "Consumer Secret"
+$twitterOauthToken     = '__set_to_your_access_token__';        // app / Keys and Access Tokens, use "Access Token" (generate access token and secret)
+$twitterOauthSecret    = '__set_to_your_access_token_secret__'; // app / Keys and Access Tokens, use "Access Token Secret" (generate access token and secret)
+
+$socialShare->registerProvider(new Twitter($twitterConsumerKey, $twitterConsumerSecret, $twitterOauthToken, $twitterOauthSecret));
 ?>
 
 <ul>

--- a/src/SocialShare/Provider/Twitter.php
+++ b/src/SocialShare/Provider/Twitter.php
@@ -4,12 +4,15 @@
  * This file is part of the SocialShare package.
  *
  * (c) Kévin Dunglas <dunglas@gmail.com>
+ *  &  Gabrijel Gavranović <gabrijel@gavro.nl>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
 namespace SocialShare\Provider;
+
+use Abraham\TwitterOAuth\TwitterOAuth;
 
 /**
  * Twitter.
@@ -20,7 +23,18 @@ class Twitter implements ProviderInterface
 {
     const NAME = 'twitter';
     const SHARE_URL = 'https://twitter.com/intent/tweet?%s';
-    const API_URL = 'https://cdn.api.twitter.com/1/urls/count.json?url=%s';
+
+    private $consumer_key    = null;
+    private $consumer_secret = null;
+    private $oauth_token     = null;
+    private $oauth_secret    = null;
+
+    public function __construct($consumerKey, $consumerSecret, $oauthToken, $oauthSecret) {
+        $this->consumer_key    = $consumerKey;
+        $this->consumer_secret = $consumerSecret;
+        $this->oauth_token     = $oauthToken;
+        $this->oauth_secret    = $oauthSecret;
+    }
 
     /**
      * {@inheritdoc}
@@ -43,10 +57,60 @@ class Twitter implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getShares($url)
+    public function getShares($url, $max_id = false) // max_id used for iterative paginated search
     {
-        $data = json_decode(file_get_contents(sprintf(self::API_URL, urlencode($url))));
+        $params = array(
+            'q'     => urlencode($url),
+            'count' => 100, // increase limit to REST API maximum: 100.
+        );
 
-        return intval($data->count);
+        if($max_id) {
+            $params['max_id'] = $max_id;
+        }
+
+        if($this->oauth_token && $this->oauth_secret) {
+            $connection = $this->getConnectionWithAccessToken($this->oauth_token, $this->oauth_secret);
+            $content = $connection->get("search/tweets", $params);
+
+            $this->count += count($content->statuses);
+
+            // paginated search, are there any 'next' results?
+            if(isset($content->search_metadata->next_results)) {
+                if($max_id_next = $this->findNext($content->search_metadata->next_results)) {
+                    $this->getShares($url, $max_id_next);
+                }
+            }
+
+            return $this->count;
+        }
+    }
+
+    private function getConnectionWithAccessToken($oauth_token, $oauth_secret)
+    {
+        if($this->consumer_key && $this->consumer_secret) {
+            $connection = new TwitterOAuth($this->consumer_key, $this->consumer_secret, $oauth_token, $oauth_secret);
+            return $connection;
+        }
+    }
+
+    private function findNext($haystack)
+    {
+        $max_id_next = false;
+        $max_id_search = explode('?', $haystack);
+
+        if(isset($max_id_search[1])) {
+            $max_id_search = explode('&', $max_id_search[1]);
+
+            foreach ($max_id_search as $key => $value) {
+                if(strpos($value, 'max_id=') !== false) {
+                    $max_id_found = explode('=', $value);
+                    if(isset($max_id_found[1])) {
+                        $max_id_next = $max_id_found[1];
+                    }
+                }
+            }
+        }
+
+        return $max_id_next;
     }
 }


### PR DESCRIPTION
Twitter count-json isn't working anymore. It's done, finished. So now we have to do the counts ourselves with an iterative search on URL via the Twitter REST API. How awkward....and so very very very inefficient....

It works, but you'll need to set up an app and use the consumer key/secret + access token/secret. Be mindfull of the API limits.

Needs some more testing. A variant of this branch is used @ http://mediaweb.nl.
